### PR TITLE
Do not use env variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,5 +20,5 @@ Usage example following Pypi installation:
 
 - ``tctalker --verbose --conf config.json report_completed $taskid1 $taskid2 [...]``
 - ``tctalker --conf config.json cancel $taskid3``
-- ``tctalker --conf rerun $taskid4``
+- ``tctalker --conf config.json rerun $taskid4``
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Installation
 Configs specification
 ---------------------
 
-Configs can served via json config file (check config.json.sample included within this repo)
+Configs can be served via json config file (check config.json.sample included within this repo)
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,7 @@ Installation
 Configs specification
 ---------------------
 
-Configs can be served in two ways:
-
-- *via json config file* (check config.json.sample included within this repo)
-- *via env vars*: **TASKCLUSTER_CLIENT_ID**, **TASKCLUSTER_ACCESS_TOKEN**, **TASKCLUSTER_CERTIFICATE**
+Configs can served via json config file (check config.json.sample included within this repo)
 
 Usage
 -----
@@ -23,5 +20,5 @@ Usage example following Pypi installation:
 
 - ``tctalker --verbose --conf config.json report_completed $taskid1 $taskid2 [...]``
 - ``tctalker --conf config.json cancel $taskid3``
-- ``tctalker rerun $taskid4`` *(assuming env vars coexist)*
+- ``tctalker --conf rerun $taskid4``
 

--- a/src/tctalker/tctalker.py
+++ b/src/tctalker/tctalker.py
@@ -40,6 +40,9 @@ class TCTalker(object):
     """The base TCTalker class"""
 
     def __init__(self, options):
+        cert = options["credentials"].get("certificate")
+        if cert and not isinstance(cert, basestring):
+            options["credentials"]["certificate"] = json.dumps(cert)
         self.queue = taskcluster.Queue(options)
         self.scheduler = taskcluster.Scheduler(options)
         log.debug("Dict of options: %s", options)

--- a/src/tctalker/tctalker.py
+++ b/src/tctalker/tctalker.py
@@ -28,18 +28,12 @@ This script is to be used to perform various operations against Taskcluster API
 (e.g. rerun, cancel, reportCompleted)
 """
 
-import os
 import json
 import logging
 import argparse
 import taskcluster
 
 log = logging.getLogger(__name__)
-
-
-def _load_json(name):
-    with open(os.path.join(os.path.dirname(__file__), name), "rb") as f:
-        return json.load(f)
 
 
 class TCTalker(object):
@@ -115,7 +109,7 @@ def main():
                         nargs="+", help="task ids to be processed")
     parser.add_argument("--conf", metavar="json-conf-file", dest="config_file",
                         help="Config file containing login information for TC",
-                        required=True)
+                        required=True, type=argparse.FileType('r'))
     parser.add_argument("-v", "--verbose", action="store_const",
                         dest="loglevel", const=logging.DEBUG,
                         default=logging.INFO,
@@ -129,7 +123,7 @@ def main():
     taskcluster_config = None
     if args.config_file:
         log.info("Attempt to read configs from json config file...")
-        taskcluster_config = _load_json(args.config_file)
+        taskcluster_config = json.load(args.config_file)
 
     log.info("Wrapping up a TCTalker object to apply <%s> action", action)
     tct = TCTalker(taskcluster_config)

--- a/src/tctalker/tctalker.py
+++ b/src/tctalker/tctalker.py
@@ -34,16 +34,6 @@ import logging
 import argparse
 import taskcluster
 
-# Default configuration
-_defaultConfig = {
-    'credentials': {
-        'clientId': os.environ.get('TASKCLUSTER_CLIENT_ID'),
-        'accessToken': os.environ.get('TASKCLUSTER_ACCESS_TOKEN'),
-        'certificate': os.environ.get('TASKCLUSTER_CERTIFICATE'),
-    },
-}
-
-
 log = logging.getLogger(__name__)
 
 
@@ -55,21 +45,10 @@ def _load_json(name):
 class TCTalker(object):
     """The base TCTalker class"""
 
-    def __init__(self, options=None):
-        o = dict()
-        o.update(_defaultConfig)
-        if options:
-            o.update(options)
-        certificate = o['credentials']['certificate']
-        try:
-            json.loads(certificate)
-        except TypeError:
-            o['credentials']['certificate'] = json.dumps(certificate)
-
-        self.options = o
-        self.queue = taskcluster.Queue(self.options)
-        self.scheduler = taskcluster.Scheduler(self.options)
-        log.debug("Dict of options: %s", self.options)
+    def __init__(self, options):
+        self.queue = taskcluster.Queue(options)
+        self.scheduler = taskcluster.Scheduler(options)
+        log.debug("Dict of options: %s", options)
 
     def _get_job_status(self, task_id):
         """Private quick method to retrieve json describing the job"""
@@ -135,7 +114,8 @@ def main():
     parser.add_argument("taskIds", metavar="$taskId1 $taskId2 ....",
                         nargs="+", help="task ids to be processed")
     parser.add_argument("--conf", metavar="json-conf-file", dest="config_file",
-                        help="Config file containing login information for TC")
+                        help="Config file containing login information for TC",
+                        required=True)
     parser.add_argument("-v", "--verbose", action="store_const",
                         dest="loglevel", const=logging.DEBUG,
                         default=logging.INFO,


### PR DESCRIPTION
I had a use case where I had no "certificate" in my config. I tried to come up with a flexible solution to handle the situation when you have it in env, but the code looked ugly.

I decided to simplify the code and get rid of env and require --conf always.
